### PR TITLE
caches /atom no_connector_typecache via SSicon_smooth

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -9,6 +9,11 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/smooth_queue = list()
 	var/list/deferred = list()
 
+	/// An associative list matching atom types to their typecaches of connector exceptions. Their no_connector_typecache var is overridden to the
+	/// element in this list associated with their type; if no such element exists, and their no_connector_typecache is nonempty, the typecache is created
+	/// according to the type's default value for no_connector_typecache, that typecache is added to this list, and the variable is set to that typecache.
+	var/list/type_no_connector_typecaches = list()
+
 /datum/controller/subsystem/icon_smooth/fire()
 	var/list/cached = smooth_queue
 	while(cached.len)
@@ -60,3 +65,12 @@ SUBSYSTEM_DEF(icon_smooth)
 	thing.smoothing_flags &= ~SMOOTH_QUEUED
 	smooth_queue -= thing
 	deferred -= thing
+
+/datum/controller/subsystem/icon_smooth/proc/get_no_connector_typecache(cache_key, list/no_connector_types, connector_strict_typing)
+	var/list/cached_typecache = type_no_connector_typecaches[cache_key]
+	if(cached_typecache)
+		return cached_typecache
+
+	var/list/new_typecache = typecacheof(no_connector_types, only_root_path = connector_strict_typing)
+	type_no_connector_typecaches[cache_key] = new_typecache
+	return new_typecache

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -142,6 +142,7 @@
 	/// The icon state prefix used for connectors. Equivalent to the base_icon_state.
 	var/connector_icon_state = null
 	/// Typecache of atom types that this wall will NOT form connector overlays into when smoothing.
+	/// Types should set this equal to a list; this list is, on init, used to create a typecache that is itself cached by SSicon_smooth.
 	var/list/no_connector_typecache = null
 	/// If true, the typecache constructed for no_connector_typecache will NOT include subtypes.
 	var/connector_strict_typing = FALSE
@@ -246,7 +247,7 @@
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 	if (length(no_connector_typecache))
-		no_connector_typecache = typecacheof(no_connector_typecache, only_root_path = connector_strict_typing)
+		no_connector_typecache = SSicon_smooth.get_no_connector_typecache(src.type, no_connector_typecache, connector_strict_typing)
 
 	var/area/ship/current_ship_area = get_area(src)
 	if(!mapload && istype(current_ship_area) && current_ship_area.mobile_port)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -64,7 +64,7 @@
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 	if (length(no_connector_typecache))
-		no_connector_typecache = typecacheof(no_connector_typecache, only_root_path = connector_strict_typing)
+		no_connector_typecache = SSicon_smooth.get_no_connector_typecache(src.type, no_connector_typecache, connector_strict_typing)
 
 	var/area/A = loc
 	if(!IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -113,7 +113,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 	if (length(no_connector_typecache))
-		no_connector_typecache = typecacheof(no_connector_typecache, only_root_path = connector_strict_typing)
+		no_connector_typecache = SSicon_smooth.get_no_connector_typecache(src.type, no_connector_typecache, connector_strict_typing)
 
 	if (smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		QUEUE_SMOOTH(src)


### PR DESCRIPTION
caches the no_connector_typecache used by turfs for dynamic connectors; i didn't like that each of them was creating its own typecache when the information was always the same. didn't do this originally because i was overthinking it way too much